### PR TITLE
[feature] agrego CRUD para cada entidad + controlador base 

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,120 @@
+class Api::V1::ArticlesController < Api::V1::BaseController
+  before_action :set_articulo, only: [ :show, :update, :destroy ]
+
+  def index
+    scope = Articulo.includes(modelo: :marca).all
+    scope = scope.joins(modelo: :marca).where(modelos: { marca_id: params[:marca_id] }) if params[:marca_id].present?
+    scope = scope.where(modelo_id: params[:modelo_id])               if params[:modelo_id].present?
+    scope = scope.where("fecha_ingreso >= ?", params[:fecha_desde])  if params[:fecha_desde].present?
+    scope = scope.where("fecha_ingreso <= ?", params[:fecha_hasta])  if params[:fecha_hasta].present?
+    scope = scope.where(persona_actual_id: params[:persona_actual_id]) if params[:persona_actual_id].present?
+
+
+    list, page, per = paginate(scope.order(fecha_ingreso: :desc, id: :asc))
+    render json: {
+      data: list.map { |a|
+        {
+          id: a.id,
+          identificador: a.identificador,
+          fecha_ingreso: a.fecha_ingreso,
+          modelo: { id: a.modelo_id, nombre: a.modelo.nombre, anio: a.modelo.anio },
+          marca:  { id: a.modelo.marca_id, nombre: a.modelo.marca.nombre },
+          persona_actual: a.persona_actual&.slice(:id, :nombre, :apellido)
+        }
+      },
+      meta: { page:, per:, total: scope.count }
+    }
+  end
+
+  def show
+    a = @articulo
+    render json: {
+      id: a.id, identificador: a.identificador, fecha_ingreso: a.fecha_ingreso,
+      modelo: { id: a.modelo_id, nombre: a.modelo.nombre, anio: a.modelo.anio },
+      marca:  { id: a.modelo.marca_id, nombre: a.modelo.marca.nombre },
+      persona_actual: a.persona_actual&.slice(:id, :nombre, :apellido)
+    }
+  end
+
+  def create
+    articulo = build_articulo_from_params!
+    articulo.save!
+    render json: { id: articulo.id }, status: :created
+  end
+
+  def update
+    if params.dig(:articulo, :persona_actual_id).present?
+      @articulo.update!(persona_actual_id: params[:articulo][:persona_actual_id])
+    end
+
+    if params.dig(:articulo, :modelo_id).present?
+      modelo = Modelo.find(params[:articulo][:modelo_id])
+      if params.dig(:articulo, :marca_id).present? && modelo.marca_id != params[:articulo][:marca_id].to_i
+        return render json: { error: "El modelo no pertenece a la marca indicada" }, status: :unprocessable_entity
+      end
+      @articulo.update!(modelo:)
+    end
+
+    @articulo.update!(identificador: params[:articulo][:identificador]) if params.dig(:articulo, :identificador)
+    @articulo.update!(fecha_ingreso: params[:articulo][:fecha_ingreso]) if params.dig(:articulo, :fecha_ingreso)
+    show
+  end
+
+  def destroy
+    if @articulo.transferencias.exists?
+      return render json: { error: "No se puede eliminar un artículo con historial de transferencias" }, status: :unprocessable_entity
+    end
+    @articulo.destroy!
+    head :no_content
+  end
+
+  private
+
+  def set_articulo
+    @articulo = Articulo.find(params[:id])
+  end
+
+  def build_articulo_from_params!
+    attrs = articulo_params.to_h.symbolize_keys
+
+    marca = if attrs[:marca_id].present?
+      Marca.find(attrs[:marca_id])
+    elsif attrs[:marca_nombre].present?
+      Marca.find_or_create_by!(nombre: attrs[:marca_nombre])
+    end
+
+    modelo = if attrs[:modelo_id].present?
+      Modelo.find(attrs[:modelo_id])
+    elsif attrs[:modelo_nombre].present?
+      raise ActiveRecord::RecordInvalid.new(Articulo.new), "Falta anio para crear el modelo" unless attrs[:modelo_anio].present?
+      raise ActiveRecord::RecordInvalid.new(Articulo.new), "Falta marca para crear el modelo" unless marca
+      Modelo.find_or_create_by!(marca:, nombre: attrs[:modelo_nombre], anio: attrs[:modelo_anio])
+    end
+    raise ActiveRecord::RecordInvalid.new(Articulo.new), "modelo es obligatorio" unless modelo
+
+    if attrs[:marca_id].present? && modelo.marca_id != attrs[:marca_id].to_i
+      raise ActiveRecord::RecordInvalid.new(Articulo.new), "El modelo no pertenece a la marca indicada"
+    end
+
+    persona_actual =
+      if attrs[:persona_actual_id].present?
+        Persona.find(attrs[:persona_actual_id])
+      elsif attrs[:persona_nombre].present? && attrs[:persona_apellido].present?
+        Persona.find_or_create_by!(nombre: attrs[:persona_nombre], apellido: attrs[:persona_apellido])
+      end
+
+    Articulo.new(
+      identificador: attrs[:identificador],
+      fecha_ingreso: attrs[:fecha_ingreso],
+      modelo: modelo,
+      persona_actual: persona_actual
+    )
+  end
+
+  def articulo_params
+    params.require(:articulo).permit(
+      :identificador, :fecha_ingreso, :modelo_id, :marca_id, :persona_actual_id,
+      :marca_nombre, :modelo_nombre, :modelo_anio, :persona_nombre, :persona_apellido
+    )
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,33 @@
+# Los controladores deben heredar de esta clase para JSON.
+
+class Api::V1::BaseController < ApplicationController
+  protect_from_forgery with: :null_session
+  skip_before_action :require_authentication, raise: false
+  before_action :authenticate_api!
+
+  rescue_from ActiveRecord::RecordNotFound do
+    render json: { error: "Not Found" }, status: :not_found
+  end
+
+  rescue_from ActiveRecord::RecordInvalid do |e|
+    render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  rescue_from ActiveRecord::InvalidForeignKey do
+    render json: { error: "No se puede eliminar: existen registros asociados" }, status: :unprocessable_entity
+  end
+
+  private
+
+  def authenticate_api!
+    bearer = request.authorization.to_s[/^Bearer (.+)$/, 1]
+    @current_user = User.find_by(api_token: bearer)
+    render(json: { error: "Unauthorized" }, status: :unauthorized) and return unless @current_user
+  end
+
+  def paginate(scope)
+    page = params.fetch(:page, 1).to_i.clamp(1, 1_000_000)
+    per  = params.fetch(:per_page, 25).to_i.clamp(1, 100)
+    [ scope.offset((page - 1) * per).limit(per), page, per ]
+  end
+end

--- a/app/controllers/api/v1/brands_controller.rb
+++ b/app/controllers/api/v1/brands_controller.rb
@@ -1,0 +1,44 @@
+class Api::V1::BrandsController < Api::V1::BaseController
+  before_action :set_marca, only: [ :show, :update, :destroy ]
+
+  def index
+    scope = Marca.all
+    scope = scope.where("LOWER(nombre) LIKE ?", "%#{params[:q].to_s.downcase}%") if params[:q].present?
+
+    list, page, per = paginate(scope.order(:nombre))
+    render json: {
+      data: list.as_json(only: [ :id, :nombre ]),
+      meta: { page:, per:, total: scope.count }
+    }
+  end
+
+  def show
+    render json: @marca.as_json(only: [ :id, :nombre ])
+  end
+
+  def create
+    marca = Marca.new(marca_params)
+    marca.save!
+    render json: marca.as_json(only: [ :id, :nombre ]), status: :created
+  end
+
+  def update
+    @marca.update!(marca_params)
+    render json: @marca.as_json(only: [ :id, :nombre ])
+  end
+
+  def destroy
+    @marca.destroy! # FK restrict en modelos evitará borrar si tiene modelos
+    head :no_content
+  end
+
+  private
+
+  def set_marca
+    @marca = Marca.find(params[:id])
+  end
+
+  def marca_params
+    params.require(:marca).permit(:nombre)
+  end
+end

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -1,0 +1,49 @@
+class Api::V1::ModelsController < Api::V1::BaseController
+  before_action :set_modelo, only: [ :show, :update, :destroy ]
+
+  def index
+    scope = Modelo.includes(:marca).all
+    scope = scope.where(marca_id: params[:marca_id]) if params[:marca_id].present?
+    scope = scope.where("LOWER(modelos.nombre) LIKE ?", "%#{params[:q].to_s.downcase}%") if params[:q].present?
+    scope = scope.where(anio: params[:anio]) if params[:anio].present?
+
+    list, page, per = paginate(scope.order("marcas.nombre ASC, modelos.nombre ASC, modelos.anio ASC").references(:marca))
+    render json: {
+      data: list.map { |m|
+        { id: m.id, nombre: m.nombre, anio: m.anio, marca: { id: m.marca_id, nombre: m.marca.nombre } }
+      },
+      meta: { page:, per:, total: scope.count }
+    }
+  end
+
+  def show
+    m = @modelo
+    render json: { id: m.id, nombre: m.nombre, anio: m.anio, marca: { id: m.marca_id, nombre: m.marca.nombre } }
+  end
+
+  def create
+    modelo = Modelo.new(modelo_params)
+    modelo.save! # unique index [:marca_id, :nombre, :anio] protege duplicados
+    render json: { id: modelo.id }, status: :created
+  end
+
+  def update
+    @modelo.update!(modelo_params)
+    show
+  end
+
+  def destroy
+    @modelo.destroy! # FK restrict en artículos evitará borrar si tiene artículos
+    head :no_content
+  end
+
+  private
+
+  def set_modelo
+    @modelo = Modelo.find(params[:id])
+  end
+
+  def modelo_params
+    params.require(:modelo).permit(:nombre, :anio, :marca_id)
+  end
+end

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -1,0 +1,58 @@
+class Api::V1::PeopleController < Api::V1::BaseController
+  before_action :set_persona, only: [ :show, :update, :destroy ]
+
+  def index
+    scope = Persona.all
+    scope = scope.where(archivado: ActiveModel::Type::Boolean.new.cast(params[:archivado])) if params.key?(:archivado)
+    scope = scope.where("LOWER(nombre)  LIKE ?", "%#{params[:nombre].to_s.downcase}%")   if params[:nombre].present?
+    scope = scope.where("LOWER(apellido) LIKE ?", "%#{params[:apellido].to_s.downcase}%") if params[:apellido].present?
+
+    list, page, per = paginate(scope.order(:apellido, :nombre))
+    render json: { data: list.as_json(only: [ :id, :nombre, :apellido, :archivado ]),
+                   meta: { page:, per:, total: scope.count } }
+  end
+
+  def show
+    render json: @persona.as_json(only: [ :id, :nombre, :apellido, :archivado ])
+  end
+
+  def create
+    persona = Persona.new(persona_params)
+    persona.save!
+    render json: persona.as_json(only: [ :id, :nombre, :apellido, :archivado ]), status: :created
+  end
+
+  def update
+    @persona.update!(persona_params)
+    render json: @persona.as_json(only: [ :id, :nombre, :apellido, :archivado ])
+  end
+
+  # “Eliminar” = archivar si tiene historial; si no, borra
+  def destroy
+    if @persona.transferencias.exists?
+      ActiveRecord::Base.transaction do
+        Articulo.where(persona_actual_id: @persona.id).find_each do |art|
+          if (abierta = Transferencia.find_by(articulo_id: art.id, fecha_fin: nil))
+            abierta.update!(fecha_fin: Time.current, descripcion: [ abierta.descripcion, "(cerrada por archivado de persona)" ].compact.join(" "))
+          end
+          art.update!(persona_actual_id: nil)
+        end
+        @persona.update!(archivado: true)
+      end
+      head :no_content
+    else
+      @persona.destroy!
+      head :no_content
+    end
+  end
+
+  private
+
+  def set_persona
+    @persona = Persona.find(params[:id])
+  end
+
+  def persona_params
+    params.require(:persona).permit(:nombre, :apellido)
+  end
+end

--- a/app/controllers/api/v1/transfers_controller.rb
+++ b/app/controllers/api/v1/transfers_controller.rb
@@ -1,0 +1,60 @@
+class Api::V1::TransfersController < Api::V1::BaseController
+  before_action :set_transferencia, only: [ :show, :update, :destroy ]
+
+  def index
+    scope = Transferencia.includes(:articulo, :persona).all
+    scope = scope.where(articulo_id: params[:articulo_id]) if params[:articulo_id].present?
+    scope = scope.where(persona_id:  params[:persona_id])  if params[:persona_id].present?
+
+    list, page, per = paginate(scope.order(fecha_inicio: :desc, id: :desc))
+    render json: {
+      data: list.map { |t|
+        t.slice(:id, :articulo_id, :persona_id, :fecha_inicio, :fecha_fin, :descripcion)
+      },
+      meta: { page:, per:, total: scope.count }
+    }
+  end
+
+  def show
+    render json: @transferencia.slice(:id, :articulo_id, :persona_id, :fecha_inicio, :fecha_fin, :descripcion)
+  end
+
+  def create
+    articulo = Articulo.find(transfer_params[:articulo_id])
+    persona  = Persona.find(transfer_params[:persona_id])
+    inicio   = transfer_params[:fecha_inicio].presence || Time.current
+
+    Transferencia.transaction do
+      if (abierta = Transferencia.find_by(articulo_id: articulo.id, fecha_fin: nil))
+        abierta.update!(fecha_fin: inicio)
+      end
+      nueva = Transferencia.create!(
+        articulo: articulo,
+        persona: persona,
+        fecha_inicio: inicio,
+        descripcion: transfer_params[:descripcion]
+      )
+      articulo.update!(persona_actual: persona)
+      render json: nueva.slice(:id, :articulo_id, :persona_id, :fecha_inicio, :fecha_fin, :descripcion), status: :created
+    end
+  end
+
+  def update
+    @transferencia.update!(transfer_params.slice(:descripcion, :fecha_fin))
+    show
+  end
+
+  def destroy
+    render json: { error: "No se permite eliminar transferencias (trazabilidad)" }, status: :unprocessable_entity
+  end
+
+  private
+
+  def set_transferencia
+    @transferencia = Transferencia.find(params[:id])
+  end
+
+  def transfer_params
+    params.require(:transferencia).permit(:articulo_id, :persona_id, :fecha_inicio, :fecha_fin, :descripcion)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+  
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
@@ -14,9 +15,12 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   namespace :api do
     namespace :v1 do
-      resources :people
-      resources :articles
-      resources :transfers
+      # En una API JSON no usamos páginas de formulario (new, edit), solo los endpoints que reciben/mandan JSON
+      resources :people,    except: [ :new, :edit ]
+      resources :articles,  except: [ :new, :edit ]
+      resources :transfers, except: [ :new, :edit ]
+      resources :brands,    except: [ :new, :edit ]
+      resources :models,    except: [ :new, :edit ]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-  
+
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest


### PR DESCRIPTION
El controlador base sirve para:
- Evitar repetir en cada controller la lógica de auth, rescue y paginación.
- Asegurar respuestas JSON coherentes con los mismos códigos en toda la API.
- Separar claramente el flujo HTML con sesión (sitio/admin) del flujo API con tokens.